### PR TITLE
Allow for rake to be run as well as plain rspec

### DIFF
--- a/.rspec
+++ b/.rspec
@@ -1,1 +1,2 @@
 --color
+--format nested

--- a/Rakefile
+++ b/Rakefile
@@ -1,1 +1,10 @@
 require "bundler/gem_tasks"
+require 'rspec/core/rake_task'
+
+RSpec::Core::RakeTask.new(:spec) do |spec|
+  spec.pattern = 'spec/**/*_spec.rb'
+  spec.rspec_opts = ['--backtrace']
+  # spec.ruby_opts = ['-w']
+end
+
+task :default => :spec

--- a/bnet_scraper.gemspec
+++ b/bnet_scraper.gemspec
@@ -15,6 +15,7 @@ Gem::Specification.new do |s|
   s.require_paths = ["lib"]
 
   s.add_runtime_dependency 'nokogiri'
+  s.add_development_dependency 'rake'
   s.add_development_dependency 'rspec'
   s.add_development_dependency 'fakeweb'
 end


### PR DESCRIPTION
I always want to run `rake` in a new project even though I know `rspec` works as well.
