### PR TITLE
added portrait name scraping to ProfileScraper

### DIFF
--- a/lib/bnet_scraper/starcraft2.rb
+++ b/lib/bnet_scraper/starcraft2.rb
@@ -27,6 +27,58 @@ module BnetScraper
       'tw.battle.net' => 'fea'
     }
 
+    # The armory uses spritemaps that are sequentially named and have a fixed
+    # 6x6 grid. We'll simply use the portrait names, left to right, top to
+    # bottom.
+    #
+    # Note: I couldn't identify the exact names of some of these and instead of
+    # guessing, I didn't name them. Some appear in multiple files too, which 
+    # is odd.
+    #
+    # I decided th pad the arrays even if there are no images to make various
+    # helping functionality (e.g. retrieving position for a name) easier.
+    # I've also kept them in 6x6 here for better overview.
+    PORTRAITS = [
+      # http://eu.battle.net/sc2/static/local-common/images/sc2/portraits/0-75.jpg?v42
+      ['Kachinsky', 'Cade', 'Thatcher', 'Hall', 'Tiger Marine', 'Panda Marine', 
+      'General Warfield', 'Jim Raynor', 'Arcturus Mengsk', 'Sarah Kerrigan', 'Kate Lockwell', 'Rory Swann', 
+      'Egon Stetmann', 'Hill', 'Adjutant', 'Dr. Ariel Hanson', 'Gabriel Tosh', 'Matt Horner', 
+      # Could not identify in order: Raynor in a Suit? Bullmarine? Nova? 
+      # Fiery Marine?
+      'Tychus Findlay', 'Zeratul', 'Valerian Mengsk', 'Spectre', '?', '?',
+      '?', '?', 'SCV', 'Firebat', 'Vulture', 'Hellion', 
+      'Medic', 'Spartan Company', 'Wraith', 'Diamondback', 'Probe', 'Scout'],
+
+      # http://eu.battle.net/sc2/static/local-common/images/sc2/portraits/1-75.jpg?v42
+      # Special Rewards - couldn't identify most of these.
+      ['?', '?', '?', '?', '?', 'PanTerran Marine', 
+      '?', '?', '?', '?', '', '',
+      '', '', '', '', '', '',
+      '', '', '', '', '', '',
+      '', '', '', '', '', '',
+      '', '', '', '', '', ''],
+
+      # http://eu.battle.net/sc2/static/local-common/images/sc2/portraits/2-75.jpg?v42
+      ['Ghost', 'Thor', 'Battlecruiser', 'Nova', 'Zealot', 'Stalker', 
+      'Phoenix', 'Immortal', 'Void Ray', 'Colossus', 'Carrier', 'Tassadar',
+      'Reaper', 'Sentry', 'Overseer', 'Viking', 'High Templar', 'Mutalisk',
+      # Unidentified: Bird? Dog? Robot?
+      'Banshee', 'Hybrid Destroyer', 'Dark Voice', '?', '?', '?',
+      # Unidentified: Worgen? Goblin? Chef?
+      'Orian', 'Wolf Marine', 'Murloc Marine', '?', '?', 'Zealot Chef', 
+      # Unidentified: KISS Marine? Dragon Marine? Dragon? Another Raynor?
+      'Stank', 'Ornatus', '?', '?', '?', '?'],
+
+      # http://eu.battle.net/sc2/static/local-common/images/sc2/portraits/3-75.jpg?v42
+      ['Urun', 'Nyon', 'Executor', 'Mohandar', 'Selendis', 'Artanis', 
+      'Drone', 'Infested Colonist', 'Infested Marine', 'Corruptor', 'Aberration', 'Broodlord', 
+      'Overmind', 'Leviathan', 'Overlord', 'Hydralisk Marine', "Zer'atai Dark Templar", 'Goliath', 
+      # Unidentified: Satan Marine?
+      'Lenassa Dark Templar', 'Mira Han', 'Archon', 'Hybrid Reaver', 'Predator', '?',
+      'Zergling', 'Roach', 'Baneling', 'Hydralisk', 'Queen', 'Infestor', 
+      'Ultralisk', 'Queen of Blades', 'Marine', 'Marauder', 'Medivac', 'Siege Tank']
+    ]
+
     # This is a convenience method that chains calls to ProfileScraper,
     # followed by a scrape of each league returned in the `leagues` array
     # in the profile_data.  The end result is a fully scraped profile with

--- a/spec/starcraft2/profile_scraper_spec.rb
+++ b/spec/starcraft2/profile_scraper_spec.rb
@@ -96,6 +96,7 @@ describe BnetScraper::Starcraft2::ProfileScraper do
         current_team_league: 'Not Yet Ranked',
         most_played: '4v4',
         achievement_points: '3660',
+        portrait: 'Mohandar',
         leagues: [
           {
             name: "1v1 Platinum Rank 95", 
@@ -173,7 +174,8 @@ describe BnetScraper::Starcraft2::ProfileScraper do
         highest_team_league: nil,
         current_team_league: nil,
         achievement_points: nil, 
-        leagues: [] 
+        leagues: [],
+        portrait: nil
       }
 
       subject.scrape

--- a/spec/starcraft2_spec.rb
+++ b/spec/starcraft2_spec.rb
@@ -15,7 +15,8 @@ describe BnetScraper::Starcraft2 do
         :highest_solo_league => 'Platinum',
         :current_team_league => 'Not Yet Ranked',
         :highest_team_league => 'Diamond',
-        :achievement_points=>"3660", 
+        :achievement_points => '3660',
+        :portrait => 'Mohandar',
         :leagues=>[
           {:season=>"6", :size=>"4v4", :name=>"Aleksander Pepper", :division=>"Diamond", :random=>false, :bnet_id=>"2377239", :account=>"Demon"},
           {:season=>"6", :size=>"4v4", :name=>"Aleksander Pepper", :division=>"Diamond", :random=>false, :bnet_id=>"2377239", :account=>"Demon"},


### PR DESCRIPTION
I'm back with goodies!

Due to how portraits are set up, I decided to simply produce the name. I'm using something like this to get back the image map and position from the name:

```
module BnetScraper
  module Starcraft2
    # Returns the map file and position of a portrait by name
    def self.portrait_position(name)
      index = PORTRAITS.flatten(1).collect(&:downcase).index(name.to_s.downcase)
      map = (index / 36)
      map_index = (index - map * 36) + 1
      y = (map_index.to_f / 6.0).ceil.to_i - 1
      x = (map_index - (y*6)) - 1
      [map, x, y]
    end
  end
end
```

Simply using the map-size.jpg and x, y \* size in CSS.
