### PR TITLE
Documentation & Minor Fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,12 +61,12 @@ All of the scrapers take an options hash, and can be created by either passing a
 passing the account information in the options hash.  Thus, either of these two approaches work:
 
 ``` ruby
-BnetScraper::Starcraft2::ProfileScraper.new(url: 'http://us.battle.net/sc2/en/profile/12345/1/TestAccount/')
-BnetScraper::Starcraft2::ProfileScraper.new(bnet_id: '12345', account: 'TestAccount', region: 'na')
+scraper1 = BnetScraper::Starcraft2::ProfileScraper.new(url: 'http://us.battle.net/sc2/en/profile/2377239/1/Demon/')
+scraper2 = BnetScraper::Starcraft2::ProfileScraper.new(bnet_id: '2377239', account: 'Demon', region: 'na')
 ```
 
-All scrapers have a `#scrape` method that triggers the scraping and storage.  By default they will return the result,
-but an additional `#output` method exists to retrieve the results subsequent times without re-scraping.
+All scrapers have a `#scrape` method that triggers the scraping and storage.  The `#scrape` method will return an
+object containing the scraped data result.
 
 ### BnetScraper::Starcraft2::ProfileScraper
 
@@ -79,6 +79,17 @@ profile = scraper.scrape
 profile.class.name # => BnetScraper::Starcraft2::Profile
 ```
 
+Additionally, the resulting `BnetScraper::Starcraft2::Profile` object has methods to scrape additional
+information without the need of creating another scraper.  For example, if you need to pull league information up
+on a player, you may call `BnetScraper::Starcraft2::Profile#leagues` and it will scrape and store the information
+for memoized access.
+
+``` ruby
+scraper = BnetScraper::Starcraft2::ProfileScraper.new(url: 'http://us.battle.net/sc2/en/profile/2377239/1/Demon/')
+profile = scraper.scrape
+profile.leagues.map(&:division) #=> ['Bronze']
+```
+
 ### BnetScraper::Starcraft2::LeagueScraper
 
 This pulls information on a specific league for a specific account.  It is best used either in conjunction with a
@@ -87,15 +98,15 @@ profile scrape that profiles a URL, or if you happen to know the specific league
 ``` ruby
 scraper = BnetScraper::Starcraft2::LeagueScraper.new(league_id: '12345', account: 'Demon', bnet_id: '2377239')
 scraper.scrape
-# => {
-  season: '6',
-  name: 'Aleksander Pepper',
-  division: 'Diamond',
-  size: '4v4',
-  random: false,
-  bnet_id: '2377239',
-  account: 'Demon'
-}
+
+# => #<BnetScraper::Starcraft2::League:0x007f89eab7a680
+@account="Demon",
+@bnet_id="2377239",
+@division=nil,
+@name=nil,
+@random=false,
+@season=nil,
+@size=nil>
 ```
 
 ### BnetScraper::Starcraft2::AchievementScraper

--- a/README.md
+++ b/README.md
@@ -147,18 +147,20 @@ This pulls the 25 most recent matches played for an account. Note that this is o
 will likely not be as fast as in-game.
 
 ``` ruby
-scraper = BnetScraper::Starcraft2::MatchHistoryScraper.new(url: 'http://us.battle.net/sc2/en/profile/2377239/1/Demon/')
-scraper.scrape
-# => {
-  wins: '15',
-  losses: '10',
-  matches: [
-    { map_name: 'Bx Monobattle - Sand Canyon (Fix)', outcome: :win, type: 'Custom', date: '3/12/2012' },
-    { map_name: 'Deadlock Ridge', outcome: :loss, type: '4v4', date: '3/12/2012' },
-    { map_name: 'District 10', outcome: :win, type: '4v4', date: '3/12/2012' },
-    # ...
-  ]
-}
+scraper = BnetScraper::Starcraft2::MatchHistoryScraper.new(
+  url: 'http://us.battle.net/sc2/en/profile/2377239/1/Demon/'
+)
+matches = scraper.scrape
+matches.size # => 25
+wins = matches.count { |m| m.outcome == :win } # => 15
+losses = matches.count { |m| m.outcome == :loss } # => 10
+
+matches.first
+# =>  #<BnetScraper::Starcraft2::Match:0x007fef55113428
+@date="5/24/2013",
+@map_name="Queen's Nest",
+@outcome=:win,
+@type="3v3">
 ```
 
 ## BnetScraper::Starcraft2::Status

--- a/README.md
+++ b/README.md
@@ -41,8 +41,9 @@ just for you.  Call `BnetScraper::Starcraft2#full_profile_scrape` with the usual
 ProfileScraper would take, and it will eager-load the achievements, matches, and leagues.
 
 ``` ruby
-scraper = BnetScraper::Starcraft2.full_profile_scrape(url: 'http://us.battle.net/sc2/en/profile/2377239/1/Demon/')
-profile = scraper.scrape
+profile = BnetScraper::Starcraft2.full_profile_scrape(url: 'http://us.battle.net/sc2/en/profile/2377239/1/Demon/')
+profile.class.name # => 'BnetScraper::Starcraft2::Profile'
+profile.leagues.first.name # => 'Changeling Bravo'
 ```
 
 Alternatively, these scrapers can be accessed in isolation.

--- a/README.md
+++ b/README.md
@@ -102,11 +102,11 @@ scraper.scrape
 # => #<BnetScraper::Starcraft2::League:0x007f89eab7a680
 @account="Demon",
 @bnet_id="2377239",
-@division=nil,
-@name=nil,
+@division="Bronze",
+@name="Changeling Bravo",
 @random=false,
-@season=nil,
-@size=nil>
+@season="2013 Season 4",
+@size="3v3">
 ```
 
 ### BnetScraper::Starcraft2::AchievementScraper
@@ -115,33 +115,30 @@ This pulls achievement information for an account.  Note that currently only ret
 not the in-depth, by-category achievement information.
 
 ``` ruby
-scraper = BnetScraper::Starcraft2::AchievementScraper.new(url: 'http://us.battle.net/sc2/en/profile/2377239/1/Demon/')
-scraper.scrape
-# => {
-  recent: [
-    { title: 'Blink of an Eye', description: 'Complete round 24 in "Starcraft Master" without losing any stalkers', earned: '3/5/2012' },
-    { title: 'Whack-a-Roach', description: 'Complete round 9 in "Starcraft Master" in under 45 seconds', earned: '3/5/2012' },
-    { title: 'Safe Zone', description: 'Complete round 8 in "Starcraft Master" without losing any stalkers', earned: '3/5/2012' },
-    { title: 'Starcraft Master', description: 'Complete all 30 rounds in "Starcraft Master"', earned: '3/5/2012' },
-    { title: 'Starcraft Expert', description: 'Complete any 25 rounds in "Starcraft Master"', earned: '3/5/2012' },
-    { title: 'Starcraft Apprentice', description: 'Complete any 20 rounds in "Starcraft Master"', earned: '3/5/2012' }
-  ],
-  showcase: [
-    { title: 'Hot Shot', description: 'Finish a Qualification Round with an undefeated record.' },
-    { title: 'Starcraft Master', description: 'Complete all rounds in "Starcraft Master"' },
-    { title: 'Team Protoss 500', description: 'Win 500 team league matches as Protoss' },
-    { title: 'Night of the Living III', description: 'Survive 15 Infested Horde Attacks in the "Night 2 Die" mode of the "Left 2 Die" scenario.' },
-    { title: 'Team Top 100 Diamond', description: 'Finish a Season in Team Diamond Division' }
-												
-  ],
-  progress: {
-    liberty_campaign: '1580',
-    exploration: '480',
-    custom_game: '330',
-    cooperative: '660',
-    quick_match: '170'
-  }
-}
+scraper = BnetScraper::Starcraft2::AchievementScraper.new(
+  url: 'http://us.battle.net/sc2/en/profile/2377239/1/Demon/'
+)
+achievement_information = scraper.scrape
+achievement_information[:recent].size # => 6
+achievement_information[:recent].first
+# => #<BnetScraper::Starcraft2::Achievement:0x007fef52b0b488
+@description="Win 50 Team Unranked or Ranked games as Zerg.",
+@earned=#<Date: 2013-04-04 ((2456387j,0s,0n),+0s,2299161j)>,
+@title="50 Wins: Team Zerg">
+
+achievement_information[:progress]
+# => {:liberty_campaign=>1580,
+:swarm_campaign=>1120,
+:matchmaking=>1410,
+:custom_game=>120,
+:arcade=>220,
+:exploration=>530}
+
+achievement_information[:showcase].size # => 5
+achievement_information[:showcase].first
+# => #<BnetScraper::Starcraft2::Achievement:0x007fef52abcb08
+@description="Finish a Qualification Round with an undefeated record.",
+@title="Hot Shot">
 ```
 
 ### BnetScraper::Starcraft2::MatchHistoryScraper

--- a/lib/bnet_scraper/starcraft2.rb
+++ b/lib/bnet_scraper/starcraft2.rb
@@ -28,8 +28,6 @@ module BnetScraper
       'tw.battle.net' => 'fea'
     }
 
-    
-      
     # This is a convenience method that chains calls to ProfileScraper,
     # followed by a scrape of each league returned in the `leagues` array
     # in the profile_data.  The end result is a fully scraped profile with
@@ -38,13 +36,11 @@ module BnetScraper
     # See `BnetScraper::Starcraft2::ProfileScraper` for more information on
     # the parameters being sent to `#full_profile_scrape`.
     #
-    # @param bnet_id - Battle.net Account ID 
-    # @param account - Battle.net Account Name
-    # @param region  - Battle.net Account Region
-    # @return profile_data - Hash containing complete profile and league data
-    #   scraped from the website
-    def self.full_profile_scrape bnet_id, account, region = 'na'
-      profile_scraper = ProfileScraper.new bnet_id: bnet_id, account: account, region: region
+    # @param options - Hash of profile options (url, bnet_id/account/region, etc).  See 
+    #   `BnetScraper::Starcraft::BaseScraper` for more information on hash options.
+    # @return [BnetScraper::Profile] profile_data - Profile object containing complete profile and league data
+    def self.full_profile_scrape options = {}
+      profile_scraper = ProfileScraper.new options
       profile = profile_scraper.scrape
       profile.leagues.each do |league|
         league.scrape_league

--- a/lib/bnet_scraper/starcraft2/achievement_scraper.rb
+++ b/lib/bnet_scraper/starcraft2/achievement_scraper.rb
@@ -6,34 +6,32 @@ module BnetScraper
     # This pulls achievement information for an account.  Note that currently only returns the overall achievements,
     # not the in-depth, by-category achievement information.
     #
-    #  scraper = BnetScraper::Starcraft2::AchievementScraper.new(url: 'http://us.battle.net/sc2/en/profile/2377239/1/Demon/')
-    #  scraper.scrape
-    #  # => {
-    #    recent: [
-    #      { title: 'Blink of an Eye', description: 'Complete round 24 in "Starcraft Master" without losing any stalkers', earned: '3/5/2012' },
-    #      { title: 'Whack-a-Roach', description: 'Complete round 9 in "Starcraft Master" in under 45 seconds', earned: '3/5/2012' },
-    #      { title: 'Safe Zone', description: 'Complete round 8 in "Starcraft Master" without losing any stalkers', earned: '3/5/2012' },
-    #      { title: 'Starcraft Master', description: 'Complete all 30 rounds in "Starcraft Master"', earned: '3/5/2012' },
-    #      { title: 'Starcraft Expert', description: 'Complete any 25 rounds in "Starcraft Master"', earned: '3/5/2012' },
-    #      { title: 'Starcraft Apprentice', description: 'Complete any 20 rounds in "Starcraft Master"', earned: '3/5/2012' }
-    #    ],
-    #    showcase: [
-    #      { title: 'Hot Shot', description: 'Finish a Qualification Round with an undefeated record.' },
-    #      { title: 'Starcraft Master', description: 'Complete all rounds in "Starcraft Master"' },
-    #      { title: 'Team Protoss 500', description: 'Win 500 team league matches as Protoss' },
-    #      { title: 'Night of the Living III', description: 'Survive 15 Infested Horde Attacks in the "Night 2 Die" mode of the "Left 2 Die" scenario.' },
-    #      { title: 'Team Top 100 Diamond', description: 'Finish a Season in Team Diamond Division' }
-    #                          
-    #    ],
-    #    progress: {
-    #      liberty_campaign: '1580',
-    #      swarm_campaign: '480',
-    #      matchmaking: '1100',
-    #      custom_game: '330',
-    #      arcade: '660',
-    #      exploration: '170'
-    #    }
-    #  }
+    # ``` ruby
+    # scraper = BnetScraper::Starcraft2::AchievementScraper.new(
+    #     url: 'http://us.battle.net/sc2/en/profile/2377239/1/Demon/'
+    # )
+    # achievement_information = scraper.scrape
+    # achievement_information[:recent].size # => 6
+    # achievement_information[:recent].first
+    # # => #<BnetScraper::Starcraft2::Achievement:0x007fef52b0b488
+    # @description="Win 50 Team Unranked or Ranked games as Zerg.",
+    #   @earned=#<Date: 2013-04-04 ((2456387j,0s,0n),+0s,2299161j)>,
+    #   @title="50 Wins: Team Zerg">
+    #
+    # achievement_information[:progress]
+    # # => {:liberty_campaign=>1580,
+    # :swarm_campaign=>1120,
+    #   :matchmaking=>1410,
+    #   :custom_game=>120,
+    #   :arcade=>220,
+    #   :exploration=>530}
+    #
+    # achievement_information[:showcase].size # => 5
+    # achievement_information[:showcase].first
+    # # => #<BnetScraper::Starcraft2::Achievement:0x007fef52abcb08
+    # @description="Finish a Qualification Round with an undefeated record.",
+    #   @title="Hot Shot">
+    # ```
     class AchievementScraper < BaseScraper
       attr_reader :recent, :progress, :showcase, :response
 

--- a/lib/bnet_scraper/starcraft2/base_scraper.rb
+++ b/lib/bnet_scraper/starcraft2/base_scraper.rb
@@ -1,3 +1,5 @@
+require 'net/http'
+
 module BnetScraper
   module Starcraft2
     # BaseScraper handles the account information extraction. Each scraper can either be passed a profile URL or

--- a/lib/bnet_scraper/starcraft2/league.rb
+++ b/lib/bnet_scraper/starcraft2/league.rb
@@ -44,7 +44,9 @@ module BnetScraper
       end
 
       def scrape_league
-        scraped_data = LeagueScraper.new(url: href).scrape
+        scraper = LeagueScraper.new(url: href)
+        scraper.scrape
+        scraped_data = scraper.output
         scraped_data.each_key do |key|
           self.send "#{key}=", scraped_data[key]
         end

--- a/lib/bnet_scraper/starcraft2/league_scraper.rb
+++ b/lib/bnet_scraper/starcraft2/league_scraper.rb
@@ -5,17 +5,19 @@ module BnetScraper
     # This pulls information on a specific league for a specific account.  It is best used either in conjunction with a
     # profile scrape that profiles a URL, or if you happen to know the specific league\_id and can pass it as an option.
     #
-    #  scraper = BnetScraper::Starcraft2::LeagueScraper.new(league_id: '12345', account: 'Demon', bnet_id: '2377239')
-    #  scraper.scrape
-    #  # => {
-    #    season: '6',
-    #    name: 'Aleksander Pepper',
-    #    division: 'Diamond',
-    #    size: '4v4',
-    #    random: false,
-    #    bnet_id: '2377239',
-    #    account: 'Demon'
-    #  }
+    #   ``` ruby
+    #   scraper = BnetScraper::Starcraft2::LeagueScraper.new(league_id: '12345', account: 'Demon', bnet_id: '2377239')
+    #   scraper.scrape
+    #
+    #   # => #<BnetScraper::Starcraft2::League:0x007f89eab7a680
+    #   @account="Demon",
+    #   @bnet_id="2377239",
+    #   @division="Bronze",
+    #   @name="Changeling Bravo",
+    #   @random=false,
+    #   @season="2013 Season 4",
+    #   @size="3v3">
+    #   ```
     class LeagueScraper < BaseScraper
       attr_reader :league_id, :season, :size, :random, :name, :division
 

--- a/lib/bnet_scraper/starcraft2/league_scraper.rb
+++ b/lib/bnet_scraper/starcraft2/league_scraper.rb
@@ -28,6 +28,7 @@ module BnetScraper
           @league_id = options[:url].match(/http:\/\/.+\/sc2\/.+\/profile\/.+\/\d{1}\/.+\/ladder\/(.+)(#current-rank)?/).to_a[1]
         else
           @league_id = options[:league_id]
+          @url = "#{profile_url}ladder/#{@league_id}"
         end
       end
 

--- a/lib/bnet_scraper/starcraft2/league_scraper.rb
+++ b/lib/bnet_scraper/starcraft2/league_scraper.rb
@@ -42,7 +42,7 @@ module BnetScraper
           @season, @size, @random, @division, @name = header_values
           
           @random = !@random.nil?
-          output
+          League.new(output)
         else
           raise BnetScraper::InvalidProfileError
         end

--- a/lib/bnet_scraper/starcraft2/profile.rb
+++ b/lib/bnet_scraper/starcraft2/profile.rb
@@ -6,7 +6,7 @@ module BnetScraper
         :highest_solo_league, :current_team_league, :highest_team_league,
         :career_games, :games_this_season, :terran_swarm_level, :protoss_swarm_level,
         :zerg_swarm_level, :leagues, :swarm_levels, :terran_campaign_completion,
-        :zerg_campaign_completion, :clan_tag, :clan_name
+        :zerg_campaign_completion, :clan_tag, :clan_name, :account
 
       def initialize options = {}
         options.each_key do |key|

--- a/lib/bnet_scraper/starcraft2/profile_scraper.rb
+++ b/lib/bnet_scraper/starcraft2/profile_scraper.rb
@@ -4,32 +4,14 @@ require 'bnet_scraper/starcraft2/portrait'
 module BnetScraper
   module Starcraft2
     # This pulls basic profile information for an account, as well as an array of league URLs.  This is a good starting
-    # point for league scraping as it provides the league URLs necessary to do supplemental scraping.
+    # point for league scraping as it provides the league URLs necessary to do supplemental scraping. The `scrape`
+    # command returns an instance of `BnetScraper::Starcraft2::Profile` containing all relevant profile information
     #
     #   scraper = BnetScraper::Starcraft2::ProfileScraper.new(url: 'http://us.battle.net/sc2/en/profile/2377239/1/Demon/')
-    #   scraper.scrape
-    #   # => {
-    #     bnet_id: '2377239',
-    #     account: 'Demon',
-    #     bnet_index: 1,
-    #     race: 'Protoss',
-    #     wins: '684',
-    #     achievement_points: '3630',
-    #     current_solo_league: 'Not Yet Ranked',
-    #     highest_solo_league: 'Platinum',
-    #     current_team_league: 'Not Yet Ranked',
-    #     highest_team_league: 'Diamond',
-    #     career_games: '1568',
-    #     games_this_season: '0',
-    #     most_played: '4v4',
-    #     leagues: [
-    #       {
-    #         name: "1v1 Platinum Rank 95",
-    #         id:   "96905",
-    #         href: "http://us.battle.net/sc2/en/profile/2377239/1/Demon/ladder/96905#current-rank"
-    #       }
-    #     ]
-    #   }
+    #   profile = scraper.scrape
+    #   profile.class.name # => 'BnetScraper::Starcraft2::Profile'
+    #   profile.race # => 'Protoss'
+    #   profile.career_games # => '1568'
     class ProfileScraper < BaseScraper
       attr_reader :achievement_points, :career_games, :leagues, :games_this_season, 
         :highest_solo_league, :current_solo_league, :highest_team_league,
@@ -39,7 +21,7 @@ module BnetScraper
       def initialize options = {}
         super
         @leagues = []
-        @profile ||= Profile.new url: profile_url
+        @profile ||= Profile.new url: profile_url, account: account
       end
 
       def scrape

--- a/lib/bnet_scraper/starcraft2/profile_scraper.rb
+++ b/lib/bnet_scraper/starcraft2/profile_scraper.rb
@@ -3,15 +3,25 @@ require 'bnet_scraper/starcraft2/portrait'
 
 module BnetScraper
   module Starcraft2
-    # This pulls basic profile information for an account, as well as an array of league URLs.  This is a good starting
-    # point for league scraping as it provides the league URLs necessary to do supplemental scraping. The `scrape`
-    # command returns an instance of `BnetScraper::Starcraft2::Profile` containing all relevant profile information
+    #  This pulls basic profile information for an account, as well as an array of league URLs.  This is a good starting
+    #  point for league scraping as it provides the league URLs necessary to do supplemental scraping.
     #
-    #   scraper = BnetScraper::Starcraft2::ProfileScraper.new(url: 'http://us.battle.net/sc2/en/profile/2377239/1/Demon/')
-    #   profile = scraper.scrape
-    #   profile.class.name # => 'BnetScraper::Starcraft2::Profile'
-    #   profile.race # => 'Protoss'
-    #   profile.career_games # => '1568'
+    #    ``` ruby
+    #    scraper = BnetScraper::Starcraft2::ProfileScraper.new(url: 'http://us.battle.net/sc2/en/profile/2377239/1/Demon/')
+    #    profile = scraper.scrape
+    #    profile.class.name # => BnetScraper::Starcraft2::Profile
+    #    ```
+    #
+    #  Additionally, the resulting `BnetScraper::Starcraft2::Profile` object has methods to scrape additional
+    #  information without the need of creating another scraper.  For example, if you need to pull league information up
+    #  on a player, you may call `BnetScraper::Starcraft2::Profile#leagues` and it will scrape and store the information
+    #  for memoized access.
+    #
+    #  ``` ruby
+    #  scraper = BnetScraper::Starcraft2::ProfileScraper.new(url: 'http://us.battle.net/sc2/en/profile/2377239/1/Demon/')
+    #  profile = scraper.scrape
+    #  profile.leagues.map(&:division) #=> ['Bronze']
+    #  ```
     class ProfileScraper < BaseScraper
       attr_reader :achievement_points, :career_games, :leagues, :games_this_season, 
         :highest_solo_league, :current_solo_league, :highest_team_league,

--- a/spec/starcraft2/league_scraper_spec.rb
+++ b/spec/starcraft2/league_scraper_spec.rb
@@ -13,6 +13,13 @@ describe BnetScraper::Starcraft2::LeagueScraper do
     it 'should dissect the league_id from the URL' do
       subject.league_id.should == '134659'
     end
+    it 'should determine the URL if it is not present' do
+      scraper = BnetScraper::Starcraft2::LeagueScraper.new({
+        account: 'Demon', bnet_id: '2377239', league_id: '134659', bnet_index: 1
+      })
+
+      scraper.url.should == "http://us.battle.net/sc2/en/profile/2377239/1/Demon/ladder/134659"
+    end
   end
 
   describe '#scrape' do

--- a/spec/starcraft2/profile_scraper_spec.rb
+++ b/spec/starcraft2/profile_scraper_spec.rb
@@ -29,6 +29,7 @@ describe BnetScraper::Starcraft2::ProfileScraper do
     its(:zerg_swarm_level) { should == 16 }
     its(:clan_tag) { should == '[GTimes]' }
     its(:clan_name) { should == '[GTimes] Good Times' }
+    its(:account) { should == 'Demon' }
 
     it 'should have a scraped portrait' do
       output.portrait.name.should == 'Selendis'

--- a/spec/starcraft2_spec.rb
+++ b/spec/starcraft2_spec.rb
@@ -4,7 +4,7 @@ describe BnetScraper::Starcraft2 do
   describe '#full_profile_scrape' do
     subject do
       VCR.use_cassette('full_demon_scrape') do
-        BnetScraper::Starcraft2.full_profile_scrape('2377239', 'Demon')
+        BnetScraper::Starcraft2.full_profile_scrape(bnet_id: '2377239', account: 'Demon')
       end
     end
 


### PR DESCRIPTION
This updates the README with the latest versions of the API, fixes issues with scraping leagues
without supplying a URL, and causes LeagueScraper to return a League, not a hash, creating a
more consistent API scraping a league directly vs scraping a profile for its leagues.

Fixes #18
